### PR TITLE
Transfer token actions now refund remaining Etherium balances

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,3 +20,17 @@ There is also a method for delivering the tokens to all the pool's contributors 
 The operation to transition to a `Paid` state is `O(1)`. Similarly, the contributor operations (deposit eth, withdraw eth, obtain tokens) are `O(1)`. The operation to deliver tokens to all the pool's contributors is `O(n)` where `n` is the number of contributors. This operation is likely to fail for pools consisting of many contributors because of gas limits.
 
 In some cases editing the contribution limits can be an `O(n)` operation. Adding or removing a whitelist is an `O(n)` operation. Modifying an existing whitelist is an `O(w)` operation where `w` is the sum of additions and deletions on the whitelist.
+
+Development
+===========
+
+Requirements
+------------
+
+* `node 8.x`
+
+Running tests
+-------------
+
+`npm run test`
+`npm run test-only "matches test string"`

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -287,34 +287,33 @@ contract PresalePool {
 
     function withdrawAllFor(address recipient) internal {
         ParticipantState storage balance = balances[recipient];
-
         if (balance.remaining + balance.contribution == 0) {
             return;
-        } else {
-            uint total = balance.remaining;
-            balance.remaining = 0;
-
-            if (state == State.Open || state == State.Failed) {
-                total += balance.contribution;
-                poolContributionBalance -= balance.contribution;
-                balance.contribution = 0;
-            } else if (state == State.Refund) {
-                uint share = etherRefunds.claimShare(
-                    recipient,
-                    this.balance - poolRemainingBalance,
-                    [balance.contribution, poolContributionBalance]
-                );
-                poolRemainingBalance -= total;
-                total += share;
-            } else {
-                require(state == State.Paid);
-            }
-
-            Withdrawl(recipient, total, 0, 0, poolContributionBalance);
-            require(
-                recipient.call.value(total)()
-            );
         }
+
+        uint total = balance.remaining;
+        balance.remaining = 0;
+
+        if (state == State.Open || state == State.Failed) {
+            total += balance.contribution;
+            poolContributionBalance -= balance.contribution;
+            balance.contribution = 0;
+        } else if (state == State.Refund) {
+            uint share = etherRefunds.claimShare(
+                recipient,
+                this.balance - poolRemainingBalance,
+                [balance.contribution, poolContributionBalance]
+            );
+            poolRemainingBalance -= total;
+            total += share;
+        } else {
+            require(state == State.Paid);
+        }
+
+        Withdrawl(recipient, total, 0, 0, poolContributionBalance);
+        require(
+            recipient.call.value(total)()
+        );
     }
 
     function transferMyTokens() external canClaimTokens {

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -316,12 +316,6 @@ contract PresalePool {
         );
     }
 
-    function transferMyTokens() external canClaimTokens {
-        uint tokenBalance = tokenContract.balanceOf(address(this));
-        transferTokensToRecipient(msg.sender, tokenBalance);
-        withdrawAllFor(msg.sender);
-    }
-
     function transferAllTokens() external canClaimTokens {
         uint tokenBalance = tokenContract.balanceOf(address(this));
 

--- a/package.json
+++ b/package.json
@@ -4,7 +4,8 @@
   "description": "a solidity contract to pool funds for token presales",
   "directories": {},
   "scripts": {
-    "test": "mocha --reporter list --timeout 30000"
+    "test": "mocha --reporter list --timeout 30000",
+    "test-only": "mocha --reporter list --timeout 30000 -g"
   },
   "author": "",
   "license": "ISC",

--- a/test/fees.js
+++ b/test/fees.js
@@ -173,7 +173,7 @@ describe('fees', () => {
 
         let nonContributor = addresses[3];
         await util.methodWithGas(
-            PresalePool.methods.transferMyTokens(),
+            PresalePool.methods.transferTokensTo([nonContributor]),
             nonContributor
         );
 
@@ -191,7 +191,7 @@ describe('fees', () => {
         );
 
         await util.methodWithGas(
-            PresalePool.methods.transferMyTokens(),
+            PresalePool.methods.transferTokensTo([blacklisted]),
             blacklisted
         );
 
@@ -299,7 +299,7 @@ describe('fees', () => {
         );
 
         await util.methodWithGas(
-            PresalePool.methods.transferMyTokens(),
+            PresalePool.methods.transferTokensTo([creator]),
             creator
         );
 
@@ -373,7 +373,7 @@ describe('fees', () => {
         );
 
         await util.methodWithGas(
-            PresalePool.methods.transferMyTokens(),
+            PresalePool.methods.transferTokensTo([buyer1]),
             buyer1
         );
 

--- a/test/refundPresale.js
+++ b/test/refundPresale.js
@@ -304,7 +304,7 @@ describe('expectRefund', () => {
 
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.transferMyTokens(),
+                PresalePool.methods.transferTokensTo([creator]),
                 creator
             )
         );
@@ -347,7 +347,7 @@ describe('expectRefund', () => {
         );
 
         await util.methodWithGas(
-            PresalePool.methods.transferMyTokens(),
+            PresalePool.methods.transferTokensTo([creator]),
             creator
         );
 

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -373,13 +373,13 @@ describe('setToken', () => {
             await setUpPaidPoolWithTokens();
 
             // calling multiple consecutive times doesn't give you more tokens
-            await util.expectBalanceChange(web3, creator, web3.utils.toWei(0, "ether"), () => {
-                return util.expectBalanceChange(web3, buyer1, web3.utils.toWei(4, "ether"), () => {
-                    return util.expectBalanceChange(web3, buyer2, web3.utils.toWei(1, "ether"), () => {
+            await util.expectBalanceChanges(
+                web3,
+                {creator: web3.utils.toWei(0, "ether"), buyer1: web3.utils.toWei(4, "ether"), buyer2: web3.utils.toWei(1, "ether")},
+                () => {
                         return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
-                    });
-                });
-            });
+                }
+            );
             await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
                 return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
             });
@@ -418,16 +418,16 @@ describe('setToken', () => {
             await setUpPaidPoolWithTokens();
 
             // calling multiple consecutive times doesn't give you more tokens
-            await util.expectBalanceChange(web3, creator, web3.utils.toWei(0, "ether"), () => {
-                return util.expectBalanceChange(web3, buyer1, web3.utils.toWei(4, "ether"), () => {
-                    return util.expectBalanceChange(web3, buyer2, web3.utils.toWei(1, "ether"), () => {
-                        return util.methodWithGas(
-                            PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
-                            creator
-                        );
-                    });
-                });
-            });
+            await util.expectBalanceChanges(
+                web3,
+                {creator: web3.utils.toWei(0, "ether"), buyer1: web3.utils.toWei(4, "ether"), buyer2: web3.utils.toWei(1, "ether")},
+                () => {
+                    return util.methodWithGas(
+                        PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
+                        creator
+                    );
+                }
+            );
             await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
                 return util.methodWithGas(
                     PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -317,67 +317,155 @@ describe('setToken', () => {
             await setUpPaidPoolWithTokens();
 
             // calling multiple consecutive times doesn't give you more tokens
-            await util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
-            await util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
+            await util.expectBalanceChange(web3, buyer1, web3.utils.toWei(4, "ether"), () => {
+                return util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
+            });
+            await util.expectBalanceChange(web3, buyer1, web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
+            });
 
             await tokenBalanceEquals(creator, 0);
             await tokenBalanceEquals(buyer1, 20);
             await tokenBalanceEquals(buyer2, 0);
 
+            // Only buyer1 has taken tokens, so the remaining balance should be 0'd out
+            let expectedBalances = {};
+            expectedBalances[creator] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(2, "ether")
+            }
+            expectedBalances[buyer1] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(1, "ether")
+            }
+            expectedBalances[buyer2] = {
+                remaining: web3.utils.toWei(1, "ether"),
+                contribution: web3.utils.toWei(0, "ether")
+            }
+            await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(1, "ether"));
+
             await transferMoreTokensToPool(18);
-            await util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
+
+            await util.expectBalanceChange(web3, buyer1, web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(PresalePool.methods.transferMyTokens(), buyer1);
+            });
 
             await tokenBalanceEquals(creator, 0);
             await tokenBalanceEquals(buyer1, 26);
             await tokenBalanceEquals(buyer2, 0);
+
+            expectedBalances[creator] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(2, "ether")
+            }
+            expectedBalances[buyer1] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(1, "ether")
+            }
+            expectedBalances[buyer2] = {
+                remaining: web3.utils.toWei(1, "ether"),
+                contribution: web3.utils.toWei(0, "ether")
+            }
+            await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(1, "ether"));
         });
 
         it("transferAllTokens()", async () => {
             await setUpPaidPoolWithTokens();
 
             // calling multiple consecutive times doesn't give you more tokens
-            await util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
-            await util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
+            await util.expectBalanceChange(web3, creator, web3.utils.toWei(0, "ether"), () => {
+                return util.expectBalanceChange(web3, buyer1, web3.utils.toWei(4, "ether"), () => {
+                    return util.expectBalanceChange(web3, buyer2, web3.utils.toWei(1, "ether"), () => {
+                        return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
+                    });
+                });
+            });
+            await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
+            });
 
             await tokenBalanceEquals(creator, 40);
             await tokenBalanceEquals(buyer1, 20);
             await tokenBalanceEquals(buyer2, 0);
 
             await transferMoreTokensToPool(18);
-            await util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
+
+            await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
+            });
 
             await tokenBalanceEquals(creator, 52);
             await tokenBalanceEquals(buyer1, 26);
             await tokenBalanceEquals(buyer2, 0);
+
+            let expectedBalances = {};
+            expectedBalances[creator] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(2, "ether")
+            }
+            expectedBalances[buyer1] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(1, "ether")
+            }
+            expectedBalances[buyer2] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(0, "ether")
+            }
+            await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(0, "ether"));
         });
 
         it("transferTokensTo()", async () => {
             await setUpPaidPoolWithTokens();
 
             // calling multiple consecutive times doesn't give you more tokens
-            await util.methodWithGas(
-                PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
-                creator
-            );
-            await util.methodWithGas(
-                PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
-                creator
-            );
+            await util.expectBalanceChange(web3, creator, web3.utils.toWei(0, "ether"), () => {
+                return util.expectBalanceChange(web3, buyer1, web3.utils.toWei(4, "ether"), () => {
+                    return util.expectBalanceChange(web3, buyer2, web3.utils.toWei(1, "ether"), () => {
+                        return util.methodWithGas(
+                            PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
+                            creator
+                        );
+                    });
+                });
+            });
+            await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(
+                    PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),
+                    creator
+                );
+            });
 
             await tokenBalanceEquals(creator, 40);
             await tokenBalanceEquals(buyer1, 20);
             await tokenBalanceEquals(buyer2, 0);
 
             await transferMoreTokensToPool(18);
-            await util.methodWithGas(
-                PresalePool.methods.transferTokensTo([creator]),
-                creator
-            );
+
+            await util.expectBalanceChangeAddresses(web3, [creator, buyer1, buyer2], web3.utils.toWei(0, "ether"), () => {
+                return util.methodWithGas(
+                    PresalePool.methods.transferTokensTo([creator]),
+                    creator
+                );
+            });
 
             await tokenBalanceEquals(creator, 52);
             await tokenBalanceEquals(buyer1, 20);
             await tokenBalanceEquals(buyer2, 0);
 
+            let expectedBalances = {};
+            expectedBalances[creator] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(2, "ether")
+            }
+            expectedBalances[buyer1] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(1, "ether")
+            }
+            expectedBalances[buyer2] = {
+                remaining: web3.utils.toWei(0, "ether"),
+                contribution: web3.utils.toWei(0, "ether")
+            }
+            await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(0, "ether"));
         });
 
         it("skips blacklisted sender", async () => {

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -375,7 +375,8 @@ describe('setToken', () => {
             // calling multiple consecutive times doesn't give you more tokens
             await util.expectBalanceChanges(
                 web3,
-                {creator: web3.utils.toWei(0, "ether"), buyer1: web3.utils.toWei(4, "ether"), buyer2: web3.utils.toWei(1, "ether")},
+                [creator, buyer1, buyer2],
+                [0, 4, 1].map(x => web3.utils.toWei(x, "ether")),
                 () => {
                         return util.methodWithGas(PresalePool.methods.transferAllTokens(), creator);
                 }
@@ -420,7 +421,8 @@ describe('setToken', () => {
             // calling multiple consecutive times doesn't give you more tokens
             await util.expectBalanceChanges(
                 web3,
-                {creator: web3.utils.toWei(0, "ether"), buyer1: web3.utils.toWei(4, "ether"), buyer2: web3.utils.toWei(1, "ether")},
+                [creator, buyer1, buyer2],
+                [0, 4, 1].map(x => web3.utils.toWei(x, "ether")),
                 () => {
                     return util.methodWithGas(
                         PresalePool.methods.transferTokensTo([creator, buyer1, buyer2]),

--- a/test/util.js
+++ b/test/util.js
@@ -200,6 +200,29 @@ async function expectBalanceChangeAddresses(web3, addresses, expectedDifference,
     }
 }
 
+async function expectBalanceChanges(web3, addressesWithDifferences, operation) {
+    let beforeBalances = {};
+
+    for (var address in addressesWithDifferences) {
+        beforeBalances[address] = await web3.eth.getBalance(address);
+    }
+    await operation();
+
+    for (var address in addressesWithDifferences) {
+        let balanceAfterRefund = await web3.eth.getBalance(address);
+        let difference = parseInt(balanceAfterRefund) - parseInt(beforeBalances[address]);
+        let expectedDifference = addressesWithDifferences(address);
+        if (expectedDifference == 0) {
+            let differenceInEther = parseFloat(
+                web3.utils.fromWei(difference, "ether")
+            );
+            expect(differenceInEther).to.be.closeTo(0, 0.01);
+        } else {
+            expect(difference / expectedDifference).to.be.within(.98, 1.0);
+        }
+    }
+}
+
 async function expectBalanceChange(web3, address, expectedDifference, operation) {
     let balance = await web3.eth.getBalance(address);
     await operation();

--- a/test/util.js
+++ b/test/util.js
@@ -179,25 +179,12 @@ async function verifyState(web3, PresalePool, expectedBalances, expectedPoolBala
 }
 
 async function expectBalanceChangeAddresses(web3, addresses, expectedDifference, operation) {
-    let beforeBalances = [];
-
-
-    for (let i = 0; i < addresses.length; i++) {
-        beforeBalances.push(await web3.eth.getBalance(addresses[i]));
-    }
-    await operation();
-    for (let i = 0; i < addresses.length; i++) {
-        let balanceAfterRefund = await web3.eth.getBalance(addresses[i]);
-        let difference = parseInt(balanceAfterRefund) - parseInt(beforeBalances[i]);
-        if (expectedDifference == 0) {
-            let differenceInEther = parseFloat(
-                web3.utils.fromWei(difference, "ether")
-            );
-            expect(differenceInEther).to.be.closeTo(0, 0.01);
-        } else {
-            expect(difference / expectedDifference).to.be.within(.98, 1.0);
-        }
-    }
+    return expectBalanceChanges(
+        web3,
+        addresses,
+        Array(addresses.length).fill(expectedDifference),
+        operation
+    );
 }
 
 async function expectBalanceChanges(web3, addresses, differences, operation) {

--- a/test/util.js
+++ b/test/util.js
@@ -200,18 +200,18 @@ async function expectBalanceChangeAddresses(web3, addresses, expectedDifference,
     }
 }
 
-async function expectBalanceChanges(web3, addressesWithDifferences, operation) {
-    let beforeBalances = {};
+async function expectBalanceChanges(web3, addresses, differences, operation) {
+    let beforeBalances = [];
 
-    for (var address in addressesWithDifferences) {
-        beforeBalances[address] = await web3.eth.getBalance(address);
+    for (let i = 0; i < addresses.length; i++) {
+        beforeBalances.push(await web3.eth.getBalance(addresses[i]));
     }
     await operation();
 
-    for (var address in addressesWithDifferences) {
-        let balanceAfterRefund = await web3.eth.getBalance(address);
-        let difference = parseInt(balanceAfterRefund) - parseInt(beforeBalances[address]);
-        let expectedDifference = addressesWithDifferences(address);
+    for (let i = 0; i < addresses.length; i++) {
+        let balanceAfterRefund = await web3.eth.getBalance(addresses[i]);
+        let difference = parseInt(balanceAfterRefund) - parseInt(beforeBalances[i]);
+        let expectedDifference = differences[i];
         if (expectedDifference == 0) {
             let differenceInEther = parseFloat(
                 web3.utils.fromWei(difference, "ether")

--- a/test/util.js
+++ b/test/util.js
@@ -242,6 +242,7 @@ module.exports = {
     createPoolArgs: createPoolArgs,
     deployContract: deployContract,
     expectBalanceChange: expectBalanceChange,
+    expectBalanceChanges: expectBalanceChanges,
     expectBalanceChangeAddresses: expectBalanceChangeAddresses,
     expectVMException: expectVMException,
     getBalances: getBalances,


### PR DESCRIPTION
All functions that transfer tokens now also refund remaining Etherium balances, regardless of whether or not the user actually received any tokens.

fixes #3 