### PR TITLE
Put limits on maxContribution and maxPoolBalance

### DIFF
--- a/contracts/PBFeeManager.sol
+++ b/contracts/PBFeeManager.sol
@@ -65,7 +65,7 @@ contract PBFeeManager {
         );
     }
 
-    function distrbuteFees(address[] recipients) external {
+    function distributeFees(address[] recipients) external {
         Fees storage fees = feesForContract[msg.sender];
         require(fees.amount > 0);
 

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -146,7 +146,11 @@ contract PresalePool {
         validateContributionSettings();
         ContributionSettingsChanged(minContribution, maxContribution, maxPoolBalance);
 
-        restricted = _restricted;
+        if (_restricted) {
+            restricted = true;
+            WhitelistEnabled();
+        }
+
         balances[msg.sender].whitelisted = true;
 
         for (uint i = 0; i < _admins.length; i++) {

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -387,8 +387,6 @@ contract PresalePool {
         bool recompute = (minContribution < _minContribution);
         // we lowered the maxContribution threshold
         recompute = recompute || (maxContribution > _maxContribution);
-        // we did not have a maxContribution threshold and now we do
-        recompute = recompute || (maxContribution == 0 && _maxContribution > 0);
         // we want to make maxPoolBalance lower than the current pool balance
         recompute = recompute || (poolContributionBalance > _maxPoolBalance);
 
@@ -484,13 +482,12 @@ contract PresalePool {
     }
 
     function validateContributionSettings() internal constant {
-        if (maxContribution > 0) {
-            require(maxContribution >= minContribution);
-        }
-        if (maxPoolBalance > 0) {
-            require(maxPoolBalance >= minContribution);
-            require(maxPoolBalance >= maxContribution);
-        }
+        uint maxAllowed = 1e9 ether;
+        require(maxContribution <= maxAllowed);
+        require(maxPoolBalance <= maxAllowed);
+        require(minContribution <= maxAllowed);
+
+        require(minContribution <= maxContribution && maxContribution <= maxPoolBalance);
     }
 
     function included(address participant) internal constant returns (bool) {

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -424,11 +424,11 @@ contract PresalePool {
                 participant = toRebalance[i];
                 balance = balances[participant];
 
-                poolContributionBalance -= balance.contribution;
-                balance.remaining += balance.contribution;
-                balance.contribution = 0;
-                (balance.contribution, balance.remaining) = getContribution(participant, 0);
-                poolContributionBalance += balance.contribution;
+                uint newContribution;
+                uint newRemaining;
+                (newContribution, newRemaining) = getContribution(participant, 0);
+                poolContributionBalance = poolContributionBalance - balance.contribution + newContribution;
+                (balance.contribution, balance.remaining) = (newContribution, newRemaining);
 
                 ContributionAdjusted(
                     participant,

--- a/contracts/PresalePool.sol
+++ b/contracts/PresalePool.sol
@@ -26,6 +26,8 @@ contract PresalePool {
     uint public maxContribution;
     uint public maxPoolBalance;
 
+    uint constant public MAX_POSSIBLE_AMOUNT = 1e9 ether;
+
     address[] public participants;
 
     bool public restricted;
@@ -419,7 +421,7 @@ contract PresalePool {
                     poolContributionBalance
                 );
             }
-        } else if (toRebalance.length > 0) {
+        } else {
             for (i = 0; i < toRebalance.length; i++) {
                 participant = toRebalance[i];
                 balance = balances[participant];
@@ -508,7 +510,7 @@ contract PresalePool {
         require(
             minContribution <= maxContribution &&
             maxContribution <= maxPoolBalance &&
-            maxPoolBalance <= 1e9 ether
+            maxPoolBalance <= MAX_POSSIBLE_AMOUNT
         );
     }
 

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -109,7 +109,20 @@ describe('deploy', () => {
                 creator,
                 util.createPoolArgs({
                     minContribution: 3,
-                    maxContribution: 2
+                    maxContribution: 2,
+                    maxPoolBalance: 5
+                })
+            )
+        );
+        await util.expectVMException(
+            util.deployContract(
+                web3,
+                "PresalePool",
+                creator,
+                util.createPoolArgs({
+                    minContribution: 3,
+                    maxContribution: 0,
+                    maxPoolBalance: 5
                 })
             )
         );
@@ -118,6 +131,7 @@ describe('deploy', () => {
                 web3, "PresalePool",
                 creator,
                 util.createPoolArgs({
+                    minContribution: 0,
                     maxContribution: 2,
                     maxPoolBalance: 1
                 })
@@ -129,7 +143,8 @@ describe('deploy', () => {
                 creator,
                 util.createPoolArgs({
                     minContribution: 3,
-                    maxPoolBalance: 2
+                    maxPoolBalance: 2,
+                    maxContribution: 4
                 })
             )
         );

--- a/test/deploy.js
+++ b/test/deploy.js
@@ -28,18 +28,23 @@ describe('deploy', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs({ admins: admins })
+            util.createPoolArgs({
+                admins: admins,
+                minContribution: 0,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether"),
+            })
         );
         let poolBalance = await web3.eth.getBalance(
             PresalePool.options.address
         );
 
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0), creator);
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0), admins[0]);
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0), admins[1]);
+        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0, []), creator);
+        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0, []), admins[0]);
+        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0, []), admins[1]);
 
         await util.expectVMException(
-            util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0), nonAdmin)
+            util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, 0, []), nonAdmin)
         );
     });
 
@@ -50,7 +55,13 @@ describe('deploy', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs({ admins: admins, restricted: true })
+            util.createPoolArgs({
+                admins: admins,
+                restricted: true,
+                minContribution: 0,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether"),
+            })
         );
 
         await util.expectVMException(
@@ -76,7 +87,11 @@ describe('deploy', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                minContribution: 0,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether"),
+            })
         );
         let poolBalance = await web3.eth.getBalance(
             PresalePool.options.address
@@ -89,7 +104,11 @@ describe('deploy', () => {
         let PresalePool = await util.deployContract(
             web3, "PresalePool",
             creator,
-            util.createPoolArgs(),
+            util.createPoolArgs({
+                minContribution: 0,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether"),
+            }),
             web3.utils.toWei(5, "ether")
         );
 

--- a/test/feeManager.js
+++ b/test/feeManager.js
@@ -66,7 +66,7 @@ describe('PBFeeManager', () => {
         }
     }
 
-    async function distrbuteFees(options) {
+    async function distributeFees(options) {
         let {
             contractAddress,
             recipients,
@@ -76,7 +76,7 @@ describe('PBFeeManager', () => {
 
         await util.expectBalanceChangeAddresses(web3, recipients, expectedPayout, ()=>{
             return util.methodWithGas(
-                FeeManager.methods.distrbuteFees(recipients),
+                FeeManager.methods.distributeFees(recipients),
                 contractAddress
             );
         });
@@ -356,7 +356,7 @@ describe('PBFeeManager', () => {
             })
         );
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,
@@ -384,7 +384,7 @@ describe('PBFeeManager', () => {
             expectedTeamPayout: web3.utils.toWei(1, "ether")
         });
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,
@@ -400,7 +400,7 @@ describe('PBFeeManager', () => {
             })
         );
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,
@@ -495,14 +495,14 @@ describe('PBFeeManager', () => {
             expectedTeamPayout: web3.utils.toWei(5, "ether")
         });
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,
             expectedPayout: web3.utils.toWei(2.5, "ether")
         });
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,
@@ -530,7 +530,7 @@ describe('PBFeeManager', () => {
             expectedTeamPayout: web3.utils.toWei(1, "ether")
         });
 
-        await distrbuteFees({
+        await distributeFees({
             recipients: recipients,
             FeeManager: FeeManager,
             contractAddress: contractAddress,

--- a/test/fees.js
+++ b/test/fees.js
@@ -30,15 +30,19 @@ describe('fees', () => {
             creator,
             [[addresses[1].toLowerCase()]]
         );
+
         await util.deployContract(
             web3,
             "PresalePool",
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.49, "ether"),
-                feeManager: PBFeeManager.options.address
+                feeManager: PBFeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
+
         await util.expectVMException(
             util.deployContract(
                 web3,
@@ -46,7 +50,9 @@ describe('fees', () => {
                 creator,
                 util.createPoolArgs({
                     feesPerEther: web3.utils.toWei(0.5, "ether"),
-                    feeManager: PBFeeManager.options.address
+                    feeManager: PBFeeManager.options.address,
+                    maxContribution: web3.utils.toWei(50, "ether"),
+                    maxPoolBalance: web3.utils.toWei(50, "ether")
                 })
             )
         );
@@ -60,7 +66,9 @@ describe('fees', () => {
                 creator,
                 util.createPoolArgs({
                     feesPerEther: web3.utils.toWei(0.49, "ether"),
-                    feeManager: addresses[1].toLowerCase()
+                    feeManager: addresses[1].toLowerCase(),
+                    maxContribution: web3.utils.toWei(50, "ether"),
+                    maxPoolBalance: web3.utils.toWei(50, "ether")
                 })
             )
         );
@@ -79,8 +87,16 @@ describe('fees', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.2, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
+        );
+
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            creator,
+            web3.utils.toWei(2, "ether")
         );
 
         await util.expectVMException(
@@ -128,7 +144,9 @@ describe('fees', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.2, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
         let blacklisted = addresses[2];
@@ -223,7 +241,9 @@ describe('fees', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.2, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
 
@@ -274,7 +294,9 @@ describe('fees', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.02, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
         let TestToken = await util.deployContract(
@@ -342,7 +364,9 @@ describe('fees', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.02, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
         let TestToken = await util.deployContract(

--- a/test/open.js
+++ b/test/open.js
@@ -36,58 +36,6 @@ describe('open state', () => {
         );
     });
 
-    it('validates contribution settings in setContributionSettings', async () => {
-        // the call below succeeds if and only if minContribution <=  maxContribution <= maxPoolTotal
-        // PresalePool.methods.setContributionSettings(minContribution, maxContribution, maxPoolTotal, [])
-        await util.expectVMException(
-            util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 2, 5, []),
-                creator
-            )
-        );
-        // maxPoolBalance must exceed maxContribution
-        await util.expectVMException(
-            util.methodWithGas(
-                PresalePool.methods.setContributionSettings(0, 2, 1, []),
-                creator
-            )
-        );
-        // maxPoolBalance must exceed minContribution
-        await util.expectVMException(
-            util.methodWithGas(
-                PresalePool.methods.setContributionSettings(2, 2, 1, []),
-                creator
-            )
-        );
-        await util.expectVMException(
-            util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 2, 1, []),
-                creator
-            )
-        );
-
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 2, 3, []),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(1, 2, 3, []),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 2, 2, []),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 0, 3, []),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 0, 0, []),
-            creator
-        );
-    });
-
     it('accepts deposits', async () => {
         await util.methodWithGas(
             PresalePool.methods.deposit(),
@@ -397,7 +345,6 @@ describe('open state', () => {
         expectedBalances[buyer1].remaining = web3.utils.toWei(0, "ether");
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(5, "ether"));
     });
-
 
     it('can transition to failed state', async () => {
         await util.methodWithGas(

--- a/test/open.js
+++ b/test/open.js
@@ -29,26 +29,39 @@ describe('open state', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
     });
 
     it('validates contribution settings in setContributionSettings', async () => {
+        // the call below succeeds if and only if minContribution <=  maxContribution <= maxPoolTotal
+        // PresalePool.methods.setContributionSettings(minContribution, maxContribution, maxPoolTotal)
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 2, 0),
+                PresalePool.methods.setContributionSettings(3, 2, 5),
                 creator
             )
         );
+        // maxPoolBalance must exceed maxContribution
         await util.expectVMException(
             util.methodWithGas(
                 PresalePool.methods.setContributionSettings(0, 2, 1),
                 creator
             )
         );
+        // maxPoolBalance must exceed minContribution
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 0, 2),
+                PresalePool.methods.setContributionSettings(2, 2, 1),
+                creator
+            )
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(3, 2, 1),
                 creator
             )
         );
@@ -62,7 +75,7 @@ describe('open state', () => {
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 2, 0),
+            PresalePool.methods.setContributionSettings(0, 2, 2),
             creator
         );
         await util.methodWithGas(
@@ -70,19 +83,7 @@ describe('open state', () => {
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(3, 0, 0),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(3, 0, 3),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 3, 3),
-            creator
-        );
-        await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(3, 3, 3),
+            PresalePool.methods.setContributionSettings(0, 0, 0),
             creator
         );
     });
@@ -240,7 +241,9 @@ describe('open state', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                web3.utils.toWei(2, "ether"), 0, 0
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether")
             ),
             creator
         )
@@ -293,7 +296,9 @@ describe('open state', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, web3.utils.toWei(2, "ether"), 0
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether")
             ),
             creator
         )
@@ -360,7 +365,9 @@ describe('open state', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, 0, web3.utils.toWei(2, "ether")
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether")
             ),
             creator
         )

--- a/test/open.js
+++ b/test/open.js
@@ -38,52 +38,52 @@ describe('open state', () => {
 
     it('validates contribution settings in setContributionSettings', async () => {
         // the call below succeeds if and only if minContribution <=  maxContribution <= maxPoolTotal
-        // PresalePool.methods.setContributionSettings(minContribution, maxContribution, maxPoolTotal)
+        // PresalePool.methods.setContributionSettings(minContribution, maxContribution, maxPoolTotal, [])
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 2, 5),
+                PresalePool.methods.setContributionSettings(3, 2, 5, []),
                 creator
             )
         );
         // maxPoolBalance must exceed maxContribution
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(0, 2, 1),
+                PresalePool.methods.setContributionSettings(0, 2, 1, []),
                 creator
             )
         );
         // maxPoolBalance must exceed minContribution
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(2, 2, 1),
+                PresalePool.methods.setContributionSettings(2, 2, 1, []),
                 creator
             )
         );
         await util.expectVMException(
             util.methodWithGas(
-                PresalePool.methods.setContributionSettings(3, 2, 1),
+                PresalePool.methods.setContributionSettings(3, 2, 1, []),
                 creator
             )
         );
 
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 2, 3),
+            PresalePool.methods.setContributionSettings(0, 2, 3, []),
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(1, 2, 3),
+            PresalePool.methods.setContributionSettings(1, 2, 3, []),
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 2, 2),
+            PresalePool.methods.setContributionSettings(0, 2, 2, []),
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 0, 3),
+            PresalePool.methods.setContributionSettings(0, 0, 3, []),
             creator
         );
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 0, 0),
+            PresalePool.methods.setContributionSettings(0, 0, 0, []),
             creator
         );
     });
@@ -243,7 +243,8 @@ describe('open state', () => {
             PresalePool.methods.setContributionSettings(
                 web3.utils.toWei(2, "ether"),
                 web3.utils.toWei(50, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         )
@@ -298,7 +299,8 @@ describe('open state', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         )
@@ -367,7 +369,8 @@ describe('open state', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(2, "ether")
+                web3.utils.toWei(2, "ether"),
+                []
             ),
             creator
         )

--- a/test/pay.js
+++ b/test/pay.js
@@ -33,7 +33,10 @@ describe('pay to presale address', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
     });
 
@@ -130,7 +133,14 @@ describe('pay to presale address', () => {
             web3.utils.toWei(1, "ether")
         );
 
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(web3.utils.toWei(2, "ether"), 0, 0), creator)
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether")
+            ),
+            creator
+        )
 
         let expectedBalances = {}
         expectedBalances[buyer1] = {
@@ -167,7 +177,14 @@ describe('pay to presale address', () => {
             web3.utils.toWei(1, "ether")
         );
 
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, web3.utils.toWei(2, "ether"), 0), creator)
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether")
+            ),
+            creator
+        )
 
         let expectedBalances = {}
         expectedBalances[buyer1] = {
@@ -204,7 +221,14 @@ describe('pay to presale address', () => {
             web3.utils.toWei(1, "ether")
         );
 
-        await util.methodWithGas(PresalePool.methods.setContributionSettings(0, 0, web3.utils.toWei(2, "ether")), creator)
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether")
+            ),
+            creator
+        )
 
         let expectedBalances = {}
         expectedBalances[buyer1] = {
@@ -258,7 +282,9 @@ describe('pay to presale address', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether")
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(3, "ether")
             ),
             creator
         )
@@ -361,7 +387,9 @@ describe('pay to presale address', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, web3.utils.toWei(2, "ether"), 0
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether")
             ),
             creator
         );

--- a/test/pay.js
+++ b/test/pay.js
@@ -137,7 +137,8 @@ describe('pay to presale address', () => {
             PresalePool.methods.setContributionSettings(
                 web3.utils.toWei(2, "ether"),
                 web3.utils.toWei(50, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         )
@@ -181,7 +182,8 @@ describe('pay to presale address', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         )
@@ -225,7 +227,8 @@ describe('pay to presale address', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(2, "ether")
+                web3.utils.toWei(2, "ether"),
+                []
             ),
             creator
         )
@@ -284,7 +287,8 @@ describe('pay to presale address', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(3, "ether")
+                web3.utils.toWei(3, "ether"),
+                []
             ),
             creator
         )
@@ -389,7 +393,8 @@ describe('pay to presale address', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(2, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         );

--- a/test/refundPresale.js
+++ b/test/refundPresale.js
@@ -435,7 +435,7 @@ describe('expectRefund', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether")
+                0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether"), []
             ),
             creator
         )
@@ -528,7 +528,7 @@ describe('expectRefund', () => {
 
         await util.methodWithGas(
             PresalePool.methods.setContributionSettings(
-                0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether")
+                0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether"), []
             ),
             creator
         )

--- a/test/refundPresale.js
+++ b/test/refundPresale.js
@@ -41,7 +41,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.expectVMException(
@@ -65,7 +68,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(PresalePool.methods.fail(), creator);
@@ -91,7 +97,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -122,7 +131,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -167,7 +179,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -215,7 +230,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -274,7 +292,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -323,7 +344,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -372,7 +396,10 @@ describe('expectRefund', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
 
         await util.methodWithGas(
@@ -461,7 +488,9 @@ describe('expectRefund', () => {
             creator,
             util.createPoolArgs({
                 feesPerEther: web3.utils.toWei(0.25, "ether"),
-                feeManager: FeeManager.options.address
+                feeManager: FeeManager.options.address,
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
             })
         );
 

--- a/test/setContributionSettings.js
+++ b/test/setContributionSettings.js
@@ -1,0 +1,706 @@
+const chai = require('chai');
+
+const server = require('./server');
+const util = require('./util');
+
+const expect = chai.expect;
+const BN = require('bn.js');
+
+
+describe('setContributionSettings()', () => {
+    let creator;
+    let buyer1;
+    let buyer2;
+    let web3;
+
+    before(async () => {
+        let result = await server.setUp();
+        web3 = result.web3;
+        creator = result.addresses[0].toLowerCase();
+        buyer1 = result.addresses[1].toLowerCase();
+        buyer2 = result.addresses[2].toLowerCase();
+    });
+
+    after(async () => {
+        await server.tearDown();
+    });
+
+    let PresalePool;
+    beforeEach(async () => {
+        PresalePool = await util.deployContract(
+            web3,
+            "PresalePool",
+            creator,
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
+        );
+    });
+
+    it('limits cant exceed 1 billion eth', async () => {
+        let billionEth = web3.utils.toWei(10**9, "ether");
+        let moreThanBillionEth = web3.utils.toWei(1 + 10**9, "ether");
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(billionEth, billionEth, billionEth, []),
+            creator
+        );
+
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(0, billionEth, moreThanBillionEth, []),
+                creator
+            )
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(0, moreThanBillionEth, moreThanBillionEth, []),
+                creator
+            )
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(moreThanBillionEth, moreThanBillionEth, moreThanBillionEth, []),
+                creator
+            )
+        );
+    });
+
+    it('validates limits', async () => {
+        // the call below succeeds if and only if minContribution <=  maxContribution <= maxPoolBalance
+        // PresalePool.methods.setContributionSettings(minContribution, maxContribution, maxPoolBalance, [])
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(3, 2, 5, []),
+                creator
+            )
+        );
+        // maxPoolBalance must exceed maxContribution
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(0, 2, 1, []),
+                creator
+            )
+        );
+        // maxPoolBalance must exceed minContribution
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(2, 2, 1, []),
+                creator
+            )
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.setContributionSettings(3, 2, 1, []),
+                creator
+            )
+        );
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(0, 2, 3, []),
+            creator
+        );
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(1, 2, 3, []),
+            creator
+        );
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(0, 2, 2, []),
+            creator
+        );
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(0, 0, 3, []),
+            creator
+        );
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(0, 0, 0, []),
+            creator
+        );
+    });
+
+    it('rebalances on increases to maxContribution', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(5, "ether")
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(3, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(3, "ether"),
+            contribution: web3.utils.toWei(2, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(1, "ether"),
+            contribution: web3.utils.toWei(2, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(50, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(3, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(3, "ether"),
+                web3.utils.toWei(50, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(2, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(3, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(3, "ether"),
+                web3.utils.toWei(50, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+    });
+
+
+    it('rebalances on increases to maxPoolBalance', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(5, "ether")
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(3, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether"),
+                []
+            ),
+            creator
+        )
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(3, "ether"),
+            contribution: web3.utils.toWei(2, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(3, "ether"),
+            contribution: web3.utils.toWei(0, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(6, "ether"),
+                web3.utils.toWei(6, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(6, "ether"),
+                web3.utils.toWei(6, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(2, "ether"),
+            contribution: web3.utils.toWei(1, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(6, "ether"),
+                web3.utils.toWei(6, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(6, "ether"),
+                web3.utils.toWei(6, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+    });
+
+    it('rebalances on increases to both maxContribution and maxPoolBalance', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(5, "ether")
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(3, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(1, "ether"),
+                web3.utils.toWei(2, "ether"),
+                []
+            ),
+            creator
+        )
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(4, "ether"),
+            contribution: web3.utils.toWei(1, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(2, "ether"),
+            contribution: web3.utils.toWei(1, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(1, "ether"),
+                web3.utils.toWei(2, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(1, "ether"),
+                web3.utils.toWei(2, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(2, "ether"),
+                web3.utils.toWei(2, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(6, "ether"),
+                []
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(2, "ether"),
+            contribution: web3.utils.toWei(1, "ether")
+        }
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(6, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(6, "ether"),
+                []
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(6, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(1, "ether"),
+            contribution: web3.utils.toWei(2, "ether")
+        }
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(7, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+    });
+
+
+    it('rebalances on decreases to minContribution', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(5, "ether")
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(3, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(4, "ether"),
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(3, "ether"),
+            contribution: web3.utils.toWei(0, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        )
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+    });
+
+    it('rebalance operation ignores blacklisted participants', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(5, "ether")
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(3, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(3, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.modifyWhitelist([], [buyer2]),
+            creator
+        );
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(3, "ether"),
+            contribution: web3.utils.toWei(0, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(0, "ether"),
+                web3.utils.toWei(100, "ether"),
+                web3.utils.toWei(100, "ether"),
+                [buyer1, buyer2]
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(0, "ether"),
+                web3.utils.toWei(100, "ether"),
+                web3.utils.toWei(100, "ether"),
+                []
+            ),
+            creator
+        );
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
+    });
+
+
+    it('deposit respects contribution settings', async () => {
+        await util.methodWithGas(
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(1, "ether"),
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(10, "ether"),
+                []
+            ),
+            creator
+        )
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.deposit(),
+                buyer1,
+                web3.utils.toWei(0.5, "ether")
+            )
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.deposit(),
+                buyer1,
+                web3.utils.toWei(6, "ether")
+            )
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(4, "ether")
+        );
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.deposit(),
+                buyer2,
+                web3.utils.toWei(6, "ether")
+            )
+        );
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer2,
+            web3.utils.toWei(5, "ether")
+        );
+
+        let expectedBalances = {}
+        expectedBalances[buyer1] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(4, "ether")
+        }
+        expectedBalances[buyer2] = {
+            remaining: web3.utils.toWei(0, "ether"),
+            contribution: web3.utils.toWei(5, "ether")
+        }
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(9, "ether"));
+
+        await util.expectVMException(
+            util.methodWithGas(
+                PresalePool.methods.deposit(),
+                buyer1,
+                web3.utils.toWei(1.5, "ether")
+            )
+        );
+
+        await util.methodWithGas(
+            PresalePool.methods.deposit(),
+            buyer1,
+            web3.utils.toWei(1, "ether")
+        );
+        expectedBalances[buyer1].contribution = web3.utils.toWei(5, "ether")
+        await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(10, "ether"));
+    });
+
+});
+

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -6,7 +6,6 @@ const util = require('./util');
 const expect = chai.expect;
 
 describe('setToken', () => {
-    let defaultPoolArgs = [0, 0, 0, []];
     let creator;
     let buyer1;
     let buyer2;
@@ -36,7 +35,10 @@ describe('setToken', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
         TestToken = await util.deployContract(
             web3,

--- a/test/tokens.js
+++ b/test/tokens.js
@@ -243,7 +243,7 @@ describe('setToken', () => {
 
             await util.methodWithGas(
                 PresalePool.methods.setContributionSettings(
-                    0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether")
+                    0, web3.utils.toWei(2, "ether"), web3.utils.toWei(3, "ether"), []
                 ),
                 creator
             );

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -6,7 +6,6 @@ const util = require('./util');
 const expect = chai.expect;
 
 describe('whitelist', () => {
-    let defaultPoolArgs = [0, 0, 0, []];
     let creator;
     let buyer1;
     let buyer2;
@@ -30,7 +29,10 @@ describe('whitelist', () => {
             web3,
             "PresalePool",
             creator,
-            util.createPoolArgs()
+            util.createPoolArgs({
+                maxContribution: web3.utils.toWei(50, "ether"),
+                maxPoolBalance: web3.utils.toWei(50, "ether")
+            })
         );
     });
 
@@ -235,7 +237,11 @@ describe('whitelist', () => {
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(12, "ether"));
 
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, web3.utils.toWei(5, "ether"), 0),
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(50, "ether")
+            ),
             creator
         );
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(12, "ether"));
@@ -298,7 +304,11 @@ describe('whitelist', () => {
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(12, "ether"));
 
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(0, 0, web3.utils.toWei(6, "ether")),
+            PresalePool.methods.setContributionSettings(
+                0,
+                web3.utils.toWei(6, "ether"),
+                web3.utils.toWei(6, "ether")
+            ),
             creator
         );
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(12, "ether"));
@@ -354,7 +364,11 @@ describe('whitelist', () => {
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));
 
         await util.methodWithGas(
-            PresalePool.methods.setContributionSettings(web3.utils.toWei(5, "ether"), 0, 0),
+            PresalePool.methods.setContributionSettings(
+                web3.utils.toWei(5, "ether"),
+                web3.utils.toWei(50, "ether"),
+                web3.utils.toWei(50, "ether"),
+            ),
             creator
         );
         await util.verifyState(web3, PresalePool, expectedBalances, web3.utils.toWei(8, "ether"));

--- a/test/whitelist.js
+++ b/test/whitelist.js
@@ -240,7 +240,8 @@ describe('whitelist', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(5, "ether"),
-                web3.utils.toWei(50, "ether")
+                web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         );
@@ -307,7 +308,8 @@ describe('whitelist', () => {
             PresalePool.methods.setContributionSettings(
                 0,
                 web3.utils.toWei(6, "ether"),
-                web3.utils.toWei(6, "ether")
+                web3.utils.toWei(6, "ether"),
+                []
             ),
             creator
         );
@@ -368,6 +370,7 @@ describe('whitelist', () => {
                 web3.utils.toWei(5, "ether"),
                 web3.utils.toWei(50, "ether"),
                 web3.utils.toWei(50, "ether"),
+                []
             ),
             creator
         );


### PR DESCRIPTION
Before I was using 0 to indicate the contribution setting is not limited
but that is confusing and error prone. Instead, I've set a hard cap at 1
billion eth.

Also added a change to how we rebalance in `setContributionSettings()`